### PR TITLE
Update clause_3_references.adoc (broken link)

### DIFF
--- a/standard/clause_3_references.adoc
+++ b/standard/clause_3_references.adoc
@@ -1,7 +1,7 @@
 == References
 The following normative documents contain provisions that, through reference in this text, constitute provisions of this document. For dated references, subsequent amendments to, or revisions of, any of these publications do not apply. For undated references, the latest edition of the normative document referred to applies.
 
-Adobe development association. TIFF Revision 6.0 Final — June 3, (1992) https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFF6.pdf
+Adobe development association. TIFF Revision 6.0 Final — June 3, (1992) https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
 
 Fielding R., Lafonand Y., Reschke J.: Hypertext Transfer Protocol (HTTP/1.1): Range Requests. RFC 7233. Internet Engineering Task Force (IETF). ISSN: 2070-1721 (2014) https://datatracker.ietf.org/doc/html/rfc7233
 


### PR DESCRIPTION
The current TIFF specification reference link on adobe web site is broken. The alternative link I'm proposing is from ITU web site and is working.