### PR TITLE
changing TIFF6 broken reference link to link from ITU also in requirements files

### DIFF
--- a/standard/requirements/requirements_geotiff_format.adoc
+++ b/standard/requirements/requirements_geotiff_format.adoc
@@ -5,6 +5,6 @@
 2+|http://www.opengis.net/spec/COG/1.0/req/req-class-geotiff-format {set:cellbgcolor:#FFFFFF}
 |Target type |TIFF Encoder
 |Dependency |http://www.opengis.net/spec/GeoTIFF/1.1/req/Core
-|Dependency |https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFF6.pdf
+|Dependency |https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
 |Dependency |bigtiff.org |
 |===

--- a/standard/requirements/requirements_httprange.adoc
+++ b/standard/requirements/requirements_httprange.adoc
@@ -6,6 +6,6 @@
 |Target type |Web server
 |Dependency |https://datatracker.ietf.org/doc/html/rfc7233
 |Dependency |http://www.opengis.net/spec/GeoTIFF/1.1/req/Core
-|Dependency |https://www.adobe.io/content/dam/udp/en/open/standards/tiff/TIFF6.pdf
+|Dependency |https://www.itu.int/itudoc/itu-t/com16/tiff-fx/docs/tiff6.pdf
 |Dependency |bigtiff.org
 |===


### PR DESCRIPTION
To be consistent with the change made in the references file.
