### PR TITLE
image dimensions inconsistent clause 7

### DIFF
--- a/standard/clause_7_geotiff_format_text.adoc
+++ b/standard/clause_7_geotiff_format_text.adoc
@@ -135,8 +135,8 @@ In these cases, the following keys in the IFD0 are sufficient;
 
 [%unnumbered]
 ----
-ImageWidth = 15829
-ImageHeight = 6520
+ImageWidth = 20111
+ImageHeight = 16882
 ModelTiepointTag = (0 0 0 187334 3255440 0)
 ModelPixelScaleTag = (30 30 0)
 GeoKeyDirectoryTag:


### PR DESCRIPTION
At the end of https://github.com/opengeospatial/CloudOptimizedGeoTIFF/blob/master/standard/clause_7_geotiff_format_text.adoc
The example says
```
ImageWidth = 15829
ImageHeight = 6520
...
```
But just later the text says `In this example, IFD0 has ImageWidth=20111 and ImageHeigth=16882`

I do not see any other example that it may be reffering to.